### PR TITLE
Use empty string instead of empty bytestring when calling `send_mesage` function in default_policy.py

### DIFF
--- a/hydro/management/policy/default_policy.py
+++ b/hydro/management/policy/default_policy.py
@@ -199,7 +199,7 @@ class DefaultHydroPolicy(BaseHydroPolicy):
                          (avg_utilization, len(executor_statuses), ip))
 
             for tid in range(NUM_EXEC_THREADS):
-                send_message(self.scaler.context, b'',
+                send_message(self.scaler.context, '',
                              get_executor_depart_address(ip, tid))
 
                 if (ip, tid) in executor_statuses:


### PR DESCRIPTION
ZMQ socket's `send_string` method expects a unicode string instead of a bytestring. When calling with a bytestring it throws a `'bytes' object has no attribute 'encode'` error. So we should simply call with an empty string.